### PR TITLE
0.2.8: Deptry typo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "latex-wc"
-version = "0.2.7"
+version = "0.2.8"
 description = "Count words in LaTeX documents while ignoring commands, math, and common non-text regions."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ testpaths = ["tests"]
 root = ["src"]
 
 [tool.deptry.per_rule_ignores]
-DEP003 = ["dark_harvest"]
+DEP003 = ["latex_wc"]

--- a/uv.lock
+++ b/uv.lock
@@ -64,7 +64,7 @@ wheels = [
 
 [[package]]
 name = "latex-wc"
-version = "0.2.7"
+version = "0.2.8"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
Fixes typo that breaks deptry

## Changes
- [ ] Fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] CI
- [x] Deps

## Testing
- [x] `make lint`
- [x] `make test`
- [x] `make build`
- [x] `make deps.check`

## Notes
<!-- Anything reviewers should know -->
